### PR TITLE
Delete outdated references to flags

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux GmbH
+# Copyright (C) 2014-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@ use strict;
 use testapi;
 use autotest;
 
-autotest::loadtest "tests/boot.pm";
+autotest::loadtest 'tests/boot.pm';
 
 1;
-

--- a/tests/boot.pm
+++ b/tests/boot.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,13 +28,4 @@ sub run {
     assert_screen 'desktop', 300;
 }
 
-sub test_flags {
-    # 'fatal'          - abort whole test suite if this fails (and set overall state 'failed')
-    # 'ignore_failure' - if this module fails, it will not affect the overall result at all
-    # 'milestone'      - after this test succeeds, update 'lastgood'
-    # 'norollback'     - don't roll back to 'lastgood' snapshot if this fails
-    return { fatal => 1 };
-}
-
 1;
-


### PR DESCRIPTION
https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc#how-to-write-tests
is a better reference which we should not duplicate.