### PR TITLE
Use consistent copyright and SPDX license identifier

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -1,18 +1,5 @@
-# Copyright (C) 2014-2018 SUSE LLC
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2014-2018 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use strict;
 use testapi;

--- a/tests/boot.pm
+++ b/tests/boot.pm
@@ -1,17 +1,5 @@
-# Copyright (C) 2014-2018 SUSE LLC
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, see <http://www.gnu.org/licenses/>.
+# Copyright 2014-2018 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use base 'basetest';
 use strict;


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/98616