### PR TITLE
CI: Fix use of jq from container

### DIFF
--- a/.github/workflows/isotovideo-action.yml
+++ b/.github/workflows/isotovideo-action.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: "registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86"
+      image: "registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-jq"
     steps:
       - uses: actions/checkout@v2
       - name: install jq

--- a/.github/workflows/isotovideo-check-all-test-modules.yml
+++ b/.github/workflows/isotovideo-check-all-test-modules.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run isotovideo against test code, fail if any test module failed
-        run: podman run --rm -it -v .:/tests:Z --entrypoint '' registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86 /bin/sh -c 'zypper -n in jq && isotovideo qemu_no_kvm=1 casedir=/tests && jq .result testresults/result-*.json | grep -v ok && echo "Test modules failed" && exit 1'
+        run: podman run --rm -it -v .:/tests:Z --entrypoint '' registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-jq /bin/sh -c 'isotovideo qemu_no_kvm=1 casedir=/tests && jq .result testresults/result-*.json | grep -v ok && echo "Test modules failed" && exit 1'


### PR DESCRIPTION
In https://github.com/os-autoinst/os-autoinst-distri-example/pull/16 we changed to rely on jq in the container image however in the dependant change https://github.com/os-autoinst/os-autoinst/pull/2289 it was decided to use a separate, new container image with the suffix "-jq" so we need to use that.

Likely needs https://github.com/os-autoinst/os-autoinst/pull/2304 first