### PR TITLE
Remove `--apibase` parameter in CI example

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -23,7 +23,6 @@ jobs:
           openqa-cli schedule \
             --monitor \
             --host "${OPENQA_HOST:-https://openqa.opensuse.org}/" \
-            --apibase "api/v1" \
             --apikey "$OPENQA_API_KEY" --apisecret "$OPENQA_API_SECRET" \
             --param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml \
             DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64 TEST=simple_boot \


### PR DESCRIPTION
This parameter is not required for a normal openQA instance. It was only used to use an openQA instance that was made available under a nested path.