### PR TITLE
Revert "CI: Rely on "jq" being available in container to not run into install problems"

### DIFF
--- a/.github/workflows/isotovideo-action.yml
+++ b/.github/workflows/isotovideo-action.yml
@@ -9,6 +9,8 @@ jobs:
       image: "registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86"
     steps:
       - uses: actions/checkout@v2
+      - name: install jq
+        run: zypper -n in jq
 
       - name: Run isotovideo against test code
         run: isotovideo qemu_no_kvm=1 casedir=.

--- a/.github/workflows/isotovideo-check-all-test-modules.yml
+++ b/.github/workflows/isotovideo-check-all-test-modules.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run isotovideo against test code, fail if any test module failed
-        run: podman run --rm -it -v .:/tests:Z --entrypoint '' registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86 /bin/sh -c 'isotovideo qemu_no_kvm=1 casedir=/tests && jq .result testresults/result-*.json | grep -v ok && echo "Test modules failed" && exit 1'
+        run: podman run --rm -it -v .:/tests:Z --entrypoint '' registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86 /bin/sh -c 'zypper -n in jq && isotovideo qemu_no_kvm=1 casedir=/tests && jq .result testresults/result-*.json | grep -v ok && echo "Test modules failed" && exit 1'


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-example#16 for now until new containers can provide jq which involves some day of waiting, packages reaching Tumbleweed, etc.