### PR TITLE
Align example distribution with openqa docs & best practices

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use strict;
+use warnings;
+
 use testapi;
 use autotest;
 

--- a/tests/boot.pm
+++ b/tests/boot.pm
@@ -1,8 +1,8 @@
 # Copyright 2014-2018 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-use base 'basetest';
-use strict;
+use Mojo::Base "basetest";
+
 use testapi;
 
 sub run {


### PR DESCRIPTION
- Align `tests/boot.pm` with the documentation. It should `use Mojo::Base` as the docs state.

- Add `use strict/warnings` for non-`Mojo::Base` modules (`main.pm`).

[poo#138416](https://progress.opensuse.org/issues/138416)