### PR TITLE
Update ubuntu image to latest

### DIFF
--- a/.github/workflows/isotovideo-action.yml
+++ b/.github/workflows/isotovideo-action.yml
@@ -4,7 +4,7 @@ name: isotovideo - github action example
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: "registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-jq"
     steps:

--- a/.github/workflows/isotovideo-check-all-test-modules.yml
+++ b/.github/workflows/isotovideo-check-all-test-modules.yml
@@ -4,12 +4,7 @@ name: isotovideo - check all test modules
 on: [push, pull_request]
 jobs:
   test:
-    # "ubuntu-latest" at time of writing 2020-12-14 is Ubuntu 18.04 showing a
-    # network problem "level=error msg="could not find slirp4netns, the
-    # network namespace won't be configured: exec: \"slirp4netns\": executable
-    # file not found in $PATH""
-    # which can be fixed with a more recent version of Ubuntu explicitly
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run isotovideo against test code, fail if any test module failed


### PR DESCRIPTION
While reviewing #33 I found out that the comment about latest images is no longer relevant and in fact the latest image is now pointing to version 22.04. Let's remove the override and get back to latest image.