### PR TITLE
Fix and simplify isotovideo test result evaluation

### DIFF
--- a/.github/workflows/isotovideo-action.yml
+++ b/.github/workflows/isotovideo-action.yml
@@ -13,7 +13,4 @@ jobs:
         run: zypper -n in jq
 
       - name: Run isotovideo against test code
-        run: isotovideo qemu_no_kvm=1 casedir=.
-
-      - name: fail if any test module failed
-        run: jq .result testresults/result-*.json | grep -v ok && echo "Test modules failed" && exit 1
+        run: isotovideo --exit-status-from-test-results qemu_no_kvm=1 casedir=.

--- a/.github/workflows/isotovideo-check-all-test-modules.yml
+++ b/.github/workflows/isotovideo-check-all-test-modules.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run isotovideo against test code, fail if any test module failed
-        run: podman run --rm -it -v .:/tests:Z --entrypoint '' registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-jq /bin/sh -c 'isotovideo qemu_no_kvm=1 casedir=/tests && jq .result testresults/result-*.json | grep -v ok && echo "Test modules failed" && exit 1'
+        run: podman run --rm -it -v .:/tests:Z --entrypoint '' registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-jq /bin/sh -c 'isotovideo --exit-status-from-test-results qemu_no_kvm=1 casedir=/tests'

--- a/.github/workflows/isotovideo.yml
+++ b/.github/workflows/isotovideo.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run isotovideo against test code in happy-path scenario
-        run: podman run --rm -it -v .:/tests:Z registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86 qemu_no_kvm=1 casedir=/tests
+        run: podman run --rm -it -v .:/tests:Z registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86 --exit-status-from-test-results qemu_no_kvm=1 casedir=/tests


### PR DESCRIPTION
With the new isotovideo flag '--exit-status-from-test-results' we can simplify our evaluation of test module results as well as fix the CI usage.