### PR TITLE
Enable tidy checks in Ci

### DIFF
--- a/.github/workflows/tidy_checks.yml
+++ b/.github/workflows/tidy_checks.yml
@@ -1,0 +1,15 @@
+---
+name: tidyall
+on: [push, pull_request]
+
+jobs:
+  tidyall:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
+    steps:
+      - uses: actions/checkout@v4
+      - name: Static analysis
+        run: |
+          git config --global --add safe.directory '*'
+          ./external/os-autoinst-common/tools/tidyall --check-only $(git ls-files)

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,1 @@
+external/os-autoinst-common/.perltidyrc

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,0 +1,3 @@
+[PerlTidy]
+select = **/*.{pl,pm,t} tools/tidyall tools/perlcritic tools/update-deps
+argv = --profile=$ROOT/.perltidyrc


### PR DESCRIPTION
`.tidyallrc` doesnt work properly as a symlink, thus the new file is an actual copy from the external/os-autoinst-common.