### PR TITLE
codespace: Run chown as postStartCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "openQA Single Instance",
     "image": "registry.opensuse.org/devel/openqa/containers15.5/openqa-single-instance",
     "runArgs": [ "--privileged", "--device", "/dev/kvm", "--entrypoint", "bash" ],
-    "postCreateCommand": "chown root:kvm /dev/kvm",
+    "postStartCommand": "chown root:kvm /dev/kvm",
     "containerEnv": {
       "VNCPORT_OFFSET": "100"
     },


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/87695

It seems when run as postCreateCommand it is only run on creation, but not on recreation (when restarting a codespace). So currently after a restart the permissions are set back to what they were before.