### PR TITLE
Update os-autoinst-common subrepo

### DIFF
--- a/external/os-autoinst-common/.github/workflows/test.yaml
+++ b/external/os-autoinst-common/.github/workflows/test.yaml
@@ -1,0 +1,13 @@
+---
+name: 'Unit Tests'
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test-t

--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = 9a505a76f9835862211cdf59e07e2a3865320f49
-	parent = e21cf1ffbae9a9988a2f814e061d976da596f868
+	commit = f74e4f8e87c67ef7331695735e27d10b55e2913b
+	parent = e82d1e4d9ba3cf0a96b1e5d95dfb1fd3505ac81c
 	method = merge
 	cmdver = 0.4.6

--- a/external/os-autoinst-common/.perlcriticrc
+++ b/external/os-autoinst-common/.perlcriticrc
@@ -41,9 +41,9 @@ severity = 1
 
 # == Custom Policies
 # -- Useless quotes on hashes
-[HashKeyQuotes]
+[OpenQA::HashKeyQuotes]
 severity = 5
 
 # -- Superfluous use strict/warning.
-[RedundantStrictWarning]
+[OpenQA::RedundantStrictWarning]
 equivalent_modules = Test::Most

--- a/external/os-autoinst-common/Makefile
+++ b/external/os-autoinst-common/Makefile
@@ -8,7 +8,7 @@ update-deps:
 	tools/update-deps --cpanfile cpanfile
 
 .PHONY: test
-test: test-tidy test-critic test-yaml test-author
+test: test-tidy test-critic test-yaml test-author test-t
 
 .PHONY: test-tidy
 test-tidy:
@@ -25,3 +25,7 @@ test-yaml:
 .PHONY: test-author
 test-author:
 	prove -l -r xt/
+
+.PHONY: test-t
+test-t:
+	prove -l -r t/

--- a/external/os-autoinst-common/cpanfile
+++ b/external/os-autoinst-common/cpanfile
@@ -17,7 +17,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Community';
-    requires 'Perl::Tidy', '== 20240511.0.0';
+    requires 'Perl::Tidy', '== 20250311';
 
 };
 

--- a/external/os-autoinst-common/dependencies.yaml
+++ b/external/os-autoinst-common/dependencies.yaml
@@ -17,7 +17,7 @@ main_requires:
   perl(Module::CPANfile):
 
 develop_requires:
-  perl(Perl::Tidy): '== 20240511.0.0'
+  perl(Perl::Tidy): '== 20250311'
   perl(Code::TidyAll):
   perl(Perl::Critic):
   perl(Perl::Critic::Community):

--- a/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/ArgumentInUseStrictWarnings.pm
+++ b/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/ArgumentInUseStrictWarnings.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-package Perl::Critic::Policy::ArgumentInUseStrictWarnings;
+package Perl::Critic::Policy::OpenQA::ArgumentInUseStrictWarnings;
 
 use strict;
 use warnings;

--- a/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/HashKeyQuotes.pm
+++ b/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/HashKeyQuotes.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-package Perl::Critic::Policy::HashKeyQuotes;
+package Perl::Critic::Policy::OpenQA::HashKeyQuotes;
 
 use strict;
 use warnings;
@@ -22,8 +22,12 @@ sub applies_to { return qw(PPI::Token::Quote::Single PPI::Token::Quote::Double) 
 sub violates ($self, $elem, $document) {
     # skip anything that's not a hash key
     return () unless is_hash_key($elem);
+    # skip if it has a sibling, e.g. $h{'foo' . 'bar'}
+    return () if $elem->snext_sibling or $elem->sprevious_sibling;
 
-    my $k = $elem->literal;
+    # only some PPI::Token::Quote::* classes implement literal
+    my $k = $elem->can('literal') ? $elem->literal : $elem->string;
+
     # skip anything that has a special symbol in the content
     return () unless $k =~ m/^\w+$/;
 

--- a/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/RedundantStrictWarning.pm
+++ b/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/RedundantStrictWarning.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-package Perl::Critic::Policy::RedundantStrictWarning;
+package Perl::Critic::Policy::OpenQA::RedundantStrictWarning;
 
 use strict;
 use warnings;

--- a/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/SpaceAfterSubroutineName.pm
+++ b/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/SpaceAfterSubroutineName.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-package Perl::Critic::Policy::SpaceAfterSubroutineName;
+package Perl::Critic::Policy::OpenQA::SpaceAfterSubroutineName;
 
 use strict;
 use warnings;
@@ -68,6 +68,8 @@ sub check_complete_sub ($self, $elem, @tokens) {
     #   5. Whitespace - must be 1
     #   6. Structure - the actual code block
 
+    my $nsib = $elem->snext_sibling;
+    my $psib = $elem->sprevious_sibling;
     return () if _is_surrounded_by_one_space($tokens[2]) && _is_surrounded_by_one_space($tokens[4]);
     return $self->report_violation($elem);
 }
@@ -77,7 +79,8 @@ sub _is_block ($token) {
 }
 
 sub _is_only_one_space ($token) {
-    return $token->isa('PPI::Token::Whitespace') && $token->content eq ' ';
+    # We also allow line breaks, e.g. perltidy forces to break up long subroutine headers
+    return $token->isa('PPI::Token::Whitespace') && $token->content =~ m/^[ \n]$/;
 }
 
 sub _is_surrounded_by_one_space ($token) {

--- a/external/os-autoinst-common/t/10-perlcritic.t
+++ b/external/os-autoinst-common/t/10-perlcritic.t
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use strict;
+use warnings;
+use FindBin '$Bin';
+use lib "$Bin/../lib/perlcritic";
+use Test::Perl::Critic::Policy qw/ all_policies_ok /;
+
+all_policies_ok();

--- a/external/os-autoinst-common/t/OpenQA/ArgumentInUseStrictWarnings.run
+++ b/external/os-autoinst-common/t/OpenQA/ArgumentInUseStrictWarnings.run
@@ -1,0 +1,12 @@
+## name Passing
+## failures 0
+## cut
+
+use strict;
+use warnings;
+
+## name Failing
+## failures 1
+## cut
+
+use warnings 'redefined';

--- a/external/os-autoinst-common/t/OpenQA/HashKeyQuotes.run
+++ b/external/os-autoinst-common/t/OpenQA/HashKeyQuotes.run
@@ -1,0 +1,19 @@
+my %h;
+## name Passing
+## failures 0
+## cut
+
+$h{bare} = 1;
+$h{"line\nbreak"} = 2;
+$h{'special!'} = 3;
+$h{'concatenate_' . 'strings'} = 4;
+$h{bare2 } = 5;
+
+## name Failing
+## failures 4
+## cut
+
+$h{'single'} = 1;
+$h{  'single'  } = 2;
+$h{"double"} = 3;
+$h{"double2" } = 4;

--- a/external/os-autoinst-common/t/OpenQA/RedundantStrictWarning.run
+++ b/external/os-autoinst-common/t/OpenQA/RedundantStrictWarning.run
@@ -1,0 +1,16 @@
+## name Passing
+## failures 0
+## cut
+
+use Mojo::Base 'DBIx::Class::Core';
+
+## name Passing
+## failures 0
+## TODO It can be neessary to use two modules that both enable strict
+## cut
+
+use Mojo::Base 'DBIx::Class::Core';
+
+use Moose;
+extends 'OpenQA::Schema::Result::Jobs';
+

--- a/external/os-autoinst-common/t/OpenQA/SpaceAfterSubroutineName.run
+++ b/external/os-autoinst-common/t/OpenQA/SpaceAfterSubroutineName.run
@@ -1,0 +1,31 @@
+## name Passing
+## failures 0
+## cut
+
+sub long ($self, $jobid, $job_labels, $aggregated, $failed_modules, $actually_failed_modules,
+    $todo = undef)
+{
+}
+
+sub long2
+($x, $y) {
+}
+
+sub a ($x) {
+}
+
+## name Failing
+## failures 4
+## cut
+
+sub foo($x) {
+}
+
+sub foo ($x){
+}
+
+sub foo  ($x) {
+}
+
+sub foo ($x)  {
+}

--- a/external/os-autoinst-common/tools/perlcritic
+++ b/external/os-autoinst-common/tools/perlcritic
@@ -5,6 +5,7 @@
 # perlcritic with auto-injection of custom perlcritic rules.
 use strict;
 use warnings;
+use v5.10;
 use experimental 'signatures';
 use FindBin '$Bin';
 
@@ -16,5 +17,8 @@ sub extra_include_paths (@extra_paths) {
 }
 
 $ENV{PERL5LIB} = join(':', (extra_include_paths('lib/perlcritic'), $ENV{PERL5LIB} // ''));
-
+unless (@ARGV) {
+    say "Usage: $0 files-or-directories";
+    exit;
+}
 exec 'perlcritic', @ARGV;

--- a/external/os-autoinst-common/tools/prove_wrapper
+++ b/external/os-autoinst-common/tools/prove_wrapper
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+
+OUTPUT=$(mktemp)
+
+echo "Running prove with TAP output check ..."
+
+prove -I . "$@" 2>&1 | tee "$OUTPUT"
+STATUS=${PIPESTATUS[0]}
+
+if [ "$STATUS" -ne 0 ]; then
+    echo "not ok - prove failed"
+    exit "$STATUS"
+fi
+
+sed -E '
+  s/^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\][[:space:]]*//
+  /^All tests successful\./,$d
+' "$OUTPUT" > "$OUTPUT.processed"
+
+UNHANDLED=$(grep -vE '^t/.*([0-9]{2}-|)([[:alnum:]]|_|-)+\.t \.+' "$OUTPUT.processed" || true)
+
+if [ -n "$UNHANDLED" ]; then
+    echo "not ok - unhandled output found"
+    echo "Run with PROVE_COMMAND=tools/prove_wrapper to reproduce locally"
+    exit 1
+else
+    echo "ok - no unhandled output found"
+    exit 0
+fi

--- a/external/os-autoinst-common/tools/tidyall
+++ b/external/os-autoinst-common/tools/tidyall
@@ -69,3 +69,4 @@ unless ($detected_version eq $required_version) {
 }
 
 exec 'tidyall', @tidyall_argv;
+exit 1;


### PR DESCRIPTION
perltidy was complaining about the Perl::Tidy version
```
git subrepo pull (merge) external/os-autoinst-common
subrepo:
  subdir:   "external/os-autoinst-common"
  merged:   "f74e4f8"
upstream:
  origin:   "https://github.com/os-autoinst/os-autoinst-common.git"
  branch:   "master"
  commit:   "f74e4f8"
git-subrepo:
  version:  "0.4.6"
  origin:   "git@github.com:ingydotnet/git-subrepo"
  commit:   "110b9eb"
```