### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -7,6 +7,8 @@ on:
   # The difference is that this runs always with the context of the master
   # branch. This is necessary to allow accessing the API credential secrets.
   workflow_dispatch:
+permissions:
+  contents: read
 env:
   OPENQA_HOST: ${{ secrets.OPENQA_URL }}
   OPENQA_API_KEY: ${{ secrets.OPENQA_API_KEY }}


### PR DESCRIPTION
Potential fix for [https://github.com/os-autoinst/os-autoinst-distri-example/security/code-scanning/8](https://github.com/os-autoinst/os-autoinst-distri-example/security/code-scanning/8)

Add an explicit `permissions` block at the workflow root in `.github/workflows/openqa.yml` so all jobs inherit least-privilege token access by default.  
Best single fix without changing functionality: set read-only access for repository contents (`contents: read`), which is sufficient for this workflow as shown (it does not perform writes via GitHub API in the provided snippet).

Edit region: near the top-level keys, right after `on:` (or before `env:`), add:

- `permissions:`
  - `contents: read`

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
