### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/check_critic.yml
+++ b/.github/workflows/check_critic.yml
@@ -8,6 +8,6 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Static analysis
         run: ./external/os-autoinst-common/tools/perlcritic --quiet .

--- a/.github/workflows/isotovideo-action.yml
+++ b/.github/workflows/isotovideo-action.yml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: "registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-jq"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run isotovideo against test code
         run: isotovideo --exit-status-from-test-results qemu_no_kvm=1 casedir=.

--- a/.github/workflows/isotovideo-check-all-test-modules.yml
+++ b/.github/workflows/isotovideo-check-all-test-modules.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run isotovideo against test code, fail if any test module failed
         run: >
           podman run --rm -it -v .:/tests:Z --entrypoint ''

--- a/.github/workflows/isotovideo.yml
+++ b/.github/workflows/isotovideo.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run isotovideo against test code in happy-path scenario
         run: >
           podman run --rm -it -v .:/tests:Z

--- a/.github/workflows/tidy_checks.yml
+++ b/.github/workflows/tidy_checks.yml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Static analysis
         run: |
           git config --global --add safe.directory '*'

--- a/.github/workflows/yaml-checks.yml
+++ b/.github/workflows/yaml-checks.yml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate yamls
         run: |
           yamllint --strict .


### PR DESCRIPTION
This also fixes a warning about outdated nodejs